### PR TITLE
Add Vapi recent calls integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 NEXT_PUBLIC_SITE_URL=http://localhost:3000 # Or your production URL for production builds
 NEXT_PUBLIC_GEOAPIFY_API_KEY=your_geoapify_api_key # Get free API key at https://www.geoapify.com/
+VAPI_API_KEY=your_vapi_api_key
+VAPI_API_URL=https://api.vapi.ai
 
 # For GitHub Actions deployment, these are set as secrets in the repository:
 # VERCEL_TOKEN
@@ -76,6 +78,8 @@ NEXT_PUBLIC_GEOAPIFY_API_KEY=your_geoapify_api_key # Get free API key at https:/
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`: Your Supabase public anonymous key.
 - `NEXT_PUBLIC_SITE_URL`: The canonical URL for your site. Use `http://localhost:3000` for local development.
 - `NEXT_PUBLIC_GEOAPIFY_API_KEY`: Your Geoapify API key for address autocomplete functionality. Sign up for a free account at [geoapify.com](https://www.geoapify.com/).
+- `VAPI_API_KEY`: API key for accessing your Vapi assistant data.
+- `VAPI_API_URL`: Base URL for the Vapi API (defaults to `https://api.vapi.ai`).
 
 The Vercel specific secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`) are used by the GitHub Actions workflow for deployment and should be configured as secrets in your GitHub repository settings, not in `.env.local`.
 

--- a/app/api/vapi/recent-calls/route.ts
+++ b/app/api/vapi/recent-calls/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+
+export async function GET(request: NextRequest) {
+  const apiKey = process.env.VAPI_API_KEY;
+  const baseUrl = process.env.VAPI_API_URL || 'https://api.vapi.ai';
+
+  if (!apiKey) {
+    logger.error('VAPI', 'API key not configured');
+    return NextResponse.json(
+      { error: 'VAPI API key not configured' },
+      { status: 500 }
+    );
+  }
+
+  const url = new URL('/v1/calls', baseUrl);
+  const { searchParams } = new URL(request.url);
+  const limit = searchParams.get('limit');
+  if (limit) {
+    url.searchParams.set('limit', limit);
+  }
+
+  try {
+    const res = await fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json',
+        'User-Agent': 'spoqen-dashboard/1.0',
+      },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!res.ok) {
+      logger.error('VAPI', 'API error', undefined, {
+        status: res.status,
+        statusText: res.statusText,
+      });
+      return NextResponse.json(
+        { error: 'Failed to fetch calls from VAPI' },
+        { status: res.status }
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    logger.error('VAPI', 'API request failed', error as Error);
+    return NextResponse.json(
+      { error: 'Error fetching calls from VAPI' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/recent-calls-list.tsx
+++ b/components/recent-calls-list.tsx
@@ -1,57 +1,44 @@
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Calendar, Clock, PhoneCall } from 'lucide-react';
+import { useRecentCalls } from '@/hooks/use-recent-calls';
 
 export function RecentCallsList() {
-  const recentCalls = [
-    {
-      id: 1,
-      name: 'Sarah Johnson',
-      phone: '(555) 123-4567',
-      date: 'May 24, 2025',
-      time: '10:30 AM',
-      summary:
-        'Interested in the 3-bedroom property on Oak Street. First-time homebuyer.',
-    },
-    {
-      id: 2,
-      name: 'Michael Rodriguez',
-      phone: '(555) 987-6543',
-      date: 'May 23, 2025',
-      time: '2:15 PM',
-      summary: 'Looking to sell condo in downtown. Relocating for work.',
-    },
-    {
-      id: 3,
-      name: 'Emily Chen',
-      phone: '(555) 456-7890',
-      date: 'May 22, 2025',
-      time: '4:45 PM',
-      summary: 'Wants information about listings in Westside neighborhood.',
-    },
-  ];
+  const { calls, loading, error } = useRecentCalls({ limit: 5 });
 
   return (
     <div className="space-y-4">
-      {recentCalls.map(call => (
+      {loading && <p className="text-sm text-muted-foreground">Loading...</p>}
+      {error && <p className="text-sm text-red-600">Error: {error}</p>}
+      {calls.map(call => (
         <div key={call.id} className="flex items-start space-x-4">
           <Avatar className="h-9 w-9">
-            <AvatarFallback>{call.name.charAt(0)}</AvatarFallback>
+            <AvatarFallback>
+              {call.callerName ? call.callerName.charAt(0) : '?'}
+            </AvatarFallback>
           </Avatar>
           <div className="space-y-1">
             <div className="flex items-center gap-2">
-              <p className="text-sm font-medium leading-none">{call.name}</p>
+              <p className="text-sm font-medium leading-none">
+                {call.callerName || 'Unknown'}
+              </p>
               <div className="flex items-center text-xs text-muted-foreground">
                 <PhoneCall className="mr-1 h-3 w-3" />
-                {call.phone}
+                {call.phoneNumber || 'Unknown'}
               </div>
             </div>
             <div className="flex items-center text-xs text-muted-foreground">
               <Calendar className="mr-1 h-3 w-3" />
-              {call.date}
+              {call.startedAt
+                ? new Date(call.startedAt).toLocaleDateString()
+                : ''}
               <Clock className="ml-2 mr-1 h-3 w-3" />
-              {call.time}
+              {call.startedAt
+                ? new Date(call.startedAt).toLocaleTimeString()
+                : ''}
             </div>
-            <p className="text-sm text-muted-foreground">{call.summary}</p>
+            {call.summary && (
+              <p className="text-sm text-muted-foreground">{call.summary}</p>
+            )}
           </div>
         </div>
       ))}

--- a/hooks/use-recent-calls.tsx
+++ b/hooks/use-recent-calls.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface VapiCall {
+  id: string;
+  callerName?: string;
+  phoneNumber?: string;
+  startedAt?: string;
+  summary?: string;
+  transcript?: string;
+}
+
+interface UseRecentCallsOptions {
+  limit?: number;
+}
+
+export function useRecentCalls(options: UseRecentCallsOptions = {}) {
+  const [calls, setCalls] = useState<VapiCall[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const fetchCalls = async () => {
+      try {
+        const params = new URLSearchParams();
+        if (options.limit) params.set('limit', String(options.limit));
+        const res = await fetch(`/api/vapi/recent-calls?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Request failed with ${res.status}`);
+        }
+        const data = await res.json();
+        setCalls(data.calls ?? data);
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchCalls();
+    return () => controller.abort();
+  }, [options.limit]);
+
+  return { calls, loading, error };
+}


### PR DESCRIPTION
## Summary
- add API route to fetch recent calls from Vapi
- create `useRecentCalls` hook
- update recent call list component to load real calls
- document Vapi env vars

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68508edd02c0833099db79e5f04c8d51