### PR TITLE
Add VAPI recent calls route and hook

### DIFF
--- a/app/api/vapi/recent-calls/route.ts
+++ b/app/api/vapi/recent-calls/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  return new Response('Method not allowed', { status: 405 });
+}
+
+export async function POST(request: Request) {
+  try {
+    const { limit = 5 } = await request.json();
+    const apiKey =
+      process.env.VAPI_API_KEY ||
+      process.env.VAPI_PRIVATE_KEY ||
+      process.env.VAPI_PUBLIC_KEY;
+
+    if (!apiKey) {
+      console.error('VAPI API key not configured');
+      return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+    }
+
+    const body = {
+      queries: [
+        {
+          table: 'call',
+          name: 'recent',
+          operations: [
+            { operation: 'list', limit },
+          ],
+        },
+      ],
+    };
+
+    const res = await fetch('https://api.vapi.ai/analytics', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error('VAPI API error', res.status, errorText);
+      return NextResponse.json({ error: 'VAPI request failed' }, { status: res.status });
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Unexpected error calling VAPI', error);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/components/recent-calls-list.tsx
+++ b/components/recent-calls-list.tsx
@@ -1,34 +1,17 @@
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Calendar, Clock, PhoneCall } from 'lucide-react';
+import { useRecentCalls } from '@/hooks/use-recent-calls';
 
-export function RecentCallsList() {
-  const recentCalls = [
-    {
-      id: 1,
-      name: 'Sarah Johnson',
-      phone: '(555) 123-4567',
-      date: 'May 24, 2025',
-      time: '10:30 AM',
-      summary:
-        'Interested in the 3-bedroom property on Oak Street. First-time homebuyer.',
-    },
-    {
-      id: 2,
-      name: 'Michael Rodriguez',
-      phone: '(555) 987-6543',
-      date: 'May 23, 2025',
-      time: '2:15 PM',
-      summary: 'Looking to sell condo in downtown. Relocating for work.',
-    },
-    {
-      id: 3,
-      name: 'Emily Chen',
-      phone: '(555) 456-7890',
-      date: 'May 22, 2025',
-      time: '4:45 PM',
-      summary: 'Wants information about listings in Westside neighborhood.',
-    },
-  ];
+export function RecentCallsList({ limit = 5 }: { limit?: number } = {}) {
+  const { calls: recentCalls, loading, error } = useRecentCalls(limit);
+
+  if (loading) {
+    return <p>Loading recent calls...</p>;
+  }
+
+  if (error) {
+    return <p className="text-destructive">{error}</p>;
+  }
 
   return (
     <div className="space-y-4">

--- a/hooks/use-recent-calls.tsx
+++ b/hooks/use-recent-calls.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+export interface CallRecord {
+  id: string;
+  [key: string]: any;
+}
+
+export function useRecentCalls(limit = 5) {
+  const [calls, setCalls] = useState<CallRecord[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchCalls() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/vapi/recent-calls`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ limit }),
+        });
+        if (!res.ok) {
+          throw new Error(`Request failed with ${res.status}`);
+        }
+        const data = await res.json();
+        setCalls(data);
+        setError(null);
+      } catch (err: any) {
+        setError(err.message || 'Failed to fetch');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchCalls();
+  }, [limit]);
+
+  return { calls, loading, error };
+}


### PR DESCRIPTION
## Summary
- create API route for VAPI recent calls
- add React hook to fetch recent calls
- update RecentCallsList component to use live data

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_6851693edcb08330890239375029c608