### PR TITLE
Add Vapi call analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ _AI Receptionist for Real Estate Agents_
 
 ## Overview
 
-Spoqen Dashboard is an AI-powered receptionist system designed specifically for real estate agents. This Next.js application provides intelligent customer interaction capabilities with seamless integration to Supabase for data management.
+Spoqen Dashboard is an AI-powered receptionist system designed specifically for real estate agents. This Next.js application provides intelligent customer interaction capabilities with seamless integration to Supabase for data management. The dashboard also displays your recent Vapi call logs with summaries and analytics for quick review.
 
 ## Getting Started
 
@@ -66,6 +66,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 NEXT_PUBLIC_SITE_URL=http://localhost:3000 # Or your production URL for production builds
 NEXT_PUBLIC_GEOAPIFY_API_KEY=your_geoapify_api_key # Get free API key at https://www.geoapify.com/
 VAPI_API_KEY=your_vapi_api_key
+VAPI_PRIVATE_KEY=your_vapi_private_key
 VAPI_API_URL=https://api.vapi.ai
 
 # For GitHub Actions deployment, these are set as secrets in the repository:
@@ -79,6 +80,7 @@ VAPI_API_URL=https://api.vapi.ai
 - `NEXT_PUBLIC_SITE_URL`: The canonical URL for your site. Use `http://localhost:3000` for local development.
 - `NEXT_PUBLIC_GEOAPIFY_API_KEY`: Your Geoapify API key for address autocomplete functionality. Sign up for a free account at [geoapify.com](https://www.geoapify.com/).
 - `VAPI_API_KEY`: API key for accessing your Vapi assistant data.
+- `VAPI_PRIVATE_KEY`: Private API key used for server-side Vapi requests.
 - `VAPI_API_URL`: Base URL for the Vapi API (defaults to `https://api.vapi.ai`).
 
 The Vercel specific secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`) are used by the GitHub Actions workflow for deployment and should be configured as secrets in your GitHub repository settings, not in `.env.local`.

--- a/app/api/vapi/calls/[id]/route.ts
+++ b/app/api/vapi/calls/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const apiKey = process.env.VAPI_PRIVATE_KEY;
+  const baseUrl = process.env.VAPI_API_URL || 'https://api.vapi.ai';
+
+  if (!apiKey) {
+    logger.error('VAPI', 'API key not configured');
+    return NextResponse.json(
+      { error: 'VAPI API key not configured' },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const callUrl = new URL(`/v1/calls/${params.id}`, baseUrl);
+    const callRes = await fetch(callUrl.toString(), {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json',
+        'User-Agent': 'spoqen-dashboard/1.0',
+      },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!callRes.ok) {
+      logger.error('VAPI', 'Failed to fetch call', undefined, {
+        status: callRes.status,
+      });
+      return NextResponse.json(
+        { error: 'Failed to fetch call' },
+        { status: callRes.status }
+      );
+    }
+
+    const callData = await callRes.json();
+
+    const analyticsUrl = new URL(`/v1/analytics`, baseUrl);
+    analyticsUrl.searchParams.set('callId', params.id);
+
+    const analyticsRes = await fetch(analyticsUrl.toString(), {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json',
+        'User-Agent': 'spoqen-dashboard/1.0',
+      },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!analyticsRes.ok) {
+      logger.error('VAPI', 'Failed to fetch analytics', undefined, {
+        status: analyticsRes.status,
+      });
+      return NextResponse.json(
+        { error: 'Failed to fetch analytics' },
+        { status: analyticsRes.status }
+      );
+    }
+
+    const analyticsData = await analyticsRes.json();
+
+    return NextResponse.json({ call: callData, analytics: analyticsData });
+  } catch (error) {
+    logger.error('VAPI', 'API request failed', error as Error);
+    return NextResponse.json(
+      { error: 'Error fetching call details' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -16,17 +16,10 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import {
-  Bell,
-  Calendar,
-  Clock,
-  Edit,
-  MessageSquare,
-  PhoneCall,
-  Settings,
-} from 'lucide-react';
+import { Edit } from 'lucide-react';
 import { DashboardHeader } from '@/components/dashboard-header';
 import { RecentCallsList } from '@/components/recent-calls-list';
+import { CallHistoryList } from '@/components/call-history-list';
 import { StatsCards } from '@/components/stats-cards';
 import { toast } from '@/components/ui/use-toast';
 import { logger } from '@/lib/logger';
@@ -517,92 +510,7 @@ export default function DashboardPage() {
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
-                  <div className="space-y-4">
-                    <div className="rounded-md border">
-                      <div className="p-4">
-                        <div className="grid gap-1">
-                          <div className="font-medium">Sarah Johnson</div>
-                          <div className="text-sm text-muted-foreground">
-                            <div className="flex items-center">
-                              <PhoneCall className="mr-1 h-3 w-3" />
-                              (555) 123-4567
-                            </div>
-                          </div>
-                        </div>
-                        <div className="mt-2 text-sm">
-                          <div className="flex items-center text-muted-foreground">
-                            <Calendar className="mr-1 h-3 w-3" />
-                            May 24, 2025
-                          </div>
-                          <div className="flex items-center text-muted-foreground">
-                            <Clock className="mr-1 h-3 w-3" />
-                            10:30 AM
-                          </div>
-                        </div>
-                        <div className="mt-2">
-                          <div className="text-sm font-medium">Summary:</div>
-                          <div className="text-sm text-muted-foreground">
-                            Sarah is interested in the 3-bedroom property on Oak
-                            Street. She's a first-time homebuyer and would like
-                            to schedule a viewing this weekend. Best time to
-                            call back is after 5 PM.
-                          </div>
-                        </div>
-                        <div className="mt-4 flex items-center gap-2">
-                          <Button size="sm" variant="outline">
-                            <MessageSquare className="mr-1 h-3 w-3" />
-                            Call Back
-                          </Button>
-                          <Button size="sm" variant="outline">
-                            <Bell className="mr-1 h-3 w-3" />
-                            Remind
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                    <div className="rounded-md border">
-                      <div className="p-4">
-                        <div className="grid gap-1">
-                          <div className="font-medium">Michael Rodriguez</div>
-                          <div className="text-sm text-muted-foreground">
-                            <div className="flex items-center">
-                              <PhoneCall className="mr-1 h-3 w-3" />
-                              (555) 987-6543
-                            </div>
-                          </div>
-                        </div>
-                        <div className="mt-2 text-sm">
-                          <div className="flex items-center text-muted-foreground">
-                            <Calendar className="mr-1 h-3 w-3" />
-                            May 23, 2025
-                          </div>
-                          <div className="flex items-center text-muted-foreground">
-                            <Clock className="mr-1 h-3 w-3" />
-                            2:15 PM
-                          </div>
-                        </div>
-                        <div className="mt-2">
-                          <div className="text-sm font-medium">Summary:</div>
-                          <div className="text-sm text-muted-foreground">
-                            Michael is looking to sell his condo in downtown.
-                            He's relocating for work and needs to sell within
-                            the next 2 months. He'd like to discuss valuation
-                            and listing strategy. Available anytime tomorrow.
-                          </div>
-                        </div>
-                        <div className="mt-4 flex items-center gap-2">
-                          <Button size="sm" variant="outline">
-                            <MessageSquare className="mr-1 h-3 w-3" />
-                            Call Back
-                          </Button>
-                          <Button size="sm" variant="outline">
-                            <Bell className="mr-1 h-3 w-3" />
-                            Remind
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                  <CallHistoryList />
                 </CardContent>
               </Card>
             </TabsContent>

--- a/components/call-history-list.tsx
+++ b/components/call-history-list.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import { Calendar, Clock, PhoneCall } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useRecentCalls } from '@/hooks/use-recent-calls';
+import { useCallDetails } from '@/hooks/use-call-details';
+
+export function CallHistoryList() {
+  const { calls, loading, error } = useRecentCalls();
+  const [selected, setSelected] = useState<string | null>(null);
+  const {
+    data: details,
+    loading: detailsLoading,
+    error: detailsError,
+  } = useCallDetails(selected);
+
+  return (
+    <div className="space-y-4">
+      {loading && <p className="text-sm text-muted-foreground">Loading...</p>}
+      {error && <p className="text-sm text-red-600">Error: {error}</p>}
+      {calls.map(call => (
+        <div key={call.id} className="space-y-2 rounded-md border p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="font-medium">{call.callerName || 'Unknown'}</div>
+              <div className="flex items-center text-sm text-muted-foreground">
+                <PhoneCall className="mr-1 h-3 w-3" />
+                {call.phoneNumber || 'Unknown'}
+              </div>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setSelected(selected === call.id ? null : call.id)}
+            >
+              {selected === call.id ? 'Hide Details' : 'View Details'}
+            </Button>
+          </div>
+          <div className="flex items-center text-xs text-muted-foreground">
+            <Calendar className="mr-1 h-3 w-3" />
+            {call.startedAt
+              ? new Date(call.startedAt).toLocaleDateString()
+              : ''}
+            <Clock className="ml-2 mr-1 h-3 w-3" />
+            {call.startedAt
+              ? new Date(call.startedAt).toLocaleTimeString()
+              : ''}
+          </div>
+          {selected === call.id && (
+            <div className="mt-2 space-y-2">
+              {detailsLoading && (
+                <p className="text-sm text-muted-foreground">Loading...</p>
+              )}
+              {detailsError && (
+                <p className="text-sm text-red-600">Error: {detailsError}</p>
+              )}
+              {details && (
+                <>
+                  {details.call?.analysis?.summary && (
+                    <p className="text-sm text-muted-foreground">
+                      {details.call.analysis.summary}
+                    </p>
+                  )}
+                  {details.analytics && (
+                    <pre className="whitespace-pre-wrap text-xs text-muted-foreground">
+                      {JSON.stringify(details.analytics, null, 2)}
+                    </pre>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/hooks/use-call-details.tsx
+++ b/hooks/use-call-details.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface CallAnalysis {
+  summary?: string;
+}
+
+export interface CallData {
+  analysis?: CallAnalysis;
+  [key: string]: unknown;
+}
+
+export interface CallDetailsData {
+  call?: CallData;
+  analytics?: unknown;
+}
+
+export function useCallDetails(callId: string | null) {
+  const [data, setData] = useState<CallDetailsData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!callId) return;
+    const controller = new AbortController();
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/vapi/calls/${callId}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Request failed with ${res.status}`);
+        }
+        const json = await res.json();
+        setData(json);
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+    return () => controller.abort();
+  }, [callId]);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
## Summary
- include Vapi call logs on the dashboard
- fetch per-call details and analytics
- add CallHistoryList component for the Calls tab
- document new `VAPI_PRIVATE_KEY` env var

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_b_6851d6d18fb483308482a15f8f221c4a