### PR TITLE
Add Vapi assistant update helpers

### DIFF
--- a/__tests__/vapi-assistant.test.ts
+++ b/__tests__/vapi-assistant.test.ts
@@ -1,0 +1,117 @@
+// Run with: npx tsx __tests__/vapi-assistant.test.ts
+import { updateAssistant, UpdateAssistantError } from '../src/lib/vapi/assistant';
+
+class TestRunner {
+  private tests: Array<{ name: string; fn: () => Promise<void> | void }> = [];
+  private currentSuite = '';
+
+  describe(name: string, fn: () => void) {
+    this.currentSuite = name;
+    console.log(`\n📋 ${name}`);
+    fn();
+  }
+
+  it(name: string, fn: () => Promise<void> | void) {
+    this.tests.push({ name: `${this.currentSuite} - ${name}`, fn });
+  }
+
+  expect(actual: any) {
+    return {
+      toBe: (expected: any) => {
+        if (actual !== expected) {
+          throw new Error(`Expected ${expected}, but got ${actual}`);
+        }
+      },
+      toEqual: (expected: any) => {
+        const a = JSON.stringify(actual);
+        const b = JSON.stringify(expected);
+        if (a !== b) {
+          throw new Error(`Expected ${b}, but got ${a}`);
+        }
+      },
+      toBeInstanceOf: (expected: any) => {
+        if (!(actual instanceof expected)) {
+          throw new Error(`Expected instance of ${expected.name}`);
+        }
+      },
+    };
+  }
+
+  async run() {
+    let passed = 0;
+    let failed = 0;
+
+    for (const test of this.tests) {
+      try {
+        await test.fn();
+        console.log(`  ✅ ${test.name.split(' - ')[1]}`);
+        passed++;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.log(`  ❌ ${test.name.split(' - ')[1]}: ${message}`);
+        failed++;
+      }
+    }
+
+    console.log(`\n📊 Test Results: ${passed} passed, ${failed} failed`);
+    if (failed > 0) process.exit(1);
+  }
+}
+
+const runner = new TestRunner();
+
+runner.describe('updateAssistant', () => {
+  runner.it('sends only provided fields and returns response', async () => {
+    const originalFetch = global.fetch;
+    let received: any = {};
+    global.fetch = async (url: any, options: any) => {
+      received = { url, options };
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    const dto = {
+      firstMessage: 'hi',
+      systemPrompt: 'be nice',
+      voice: { provider: 'azure', voiceId: '123' },
+    };
+
+    const res = await updateAssistant('abc', dto, 'token');
+
+    runner.expect(received.url.includes('/assistant/abc')).toBe(true);
+    runner.expect(received.options.method).toBe('PATCH');
+    const body = JSON.parse(received.options.body);
+    runner.expect(body).toEqual({
+      firstMessage: 'hi',
+      voice: { provider: 'azure', voiceId: '123' },
+      model: {
+        provider: 'openai',
+        model: 'gpt-4o',
+        messages: [{ role: 'system', content: 'be nice' }],
+      },
+    });
+    runner.expect(res).toEqual({ ok: true });
+
+    global.fetch = originalFetch;
+  });
+
+  runner.it('throws UpdateAssistantError on non-2xx', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = async () =>
+      new Response(JSON.stringify({ error: 'bad' }), { status: 400 });
+
+    let caught: any;
+    try {
+      await updateAssistant('abc', {}, 'token');
+    } catch (e) {
+      caught = e;
+    }
+
+    runner.expect(caught).toBeInstanceOf(UpdateAssistantError);
+    runner.expect((caught as UpdateAssistantError).status).toBe(400);
+    runner.expect((caught as UpdateAssistantError).body).toEqual({ error: 'bad' });
+
+    global.fetch = originalFetch;
+  });
+});
+
+runner.run();

--- a/src/lib/utils/retry.ts
+++ b/src/lib/utils/retry.ts
@@ -1,0 +1,18 @@
+export async function retry<T>(
+  fn: () => Promise<T>,
+  maxAttempts = 3,
+  delayMs = 500
+): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      attempt += 1;
+      if (attempt >= maxAttempts) {
+        throw err;
+      }
+      await new Promise(res => setTimeout(res, delayMs * 2 ** (attempt - 1)));
+    }
+  }
+}

--- a/src/lib/vapi/assistant.ts
+++ b/src/lib/vapi/assistant.ts
@@ -1,0 +1,98 @@
+import { retry } from '@/src/lib/utils/retry';
+
+export interface AssistantDTO {
+  firstMessage?: string;
+  systemPrompt?: string;
+  voice?: { provider: string; voiceId: string };
+}
+
+export class UpdateAssistantError extends Error {
+  status: number;
+  body: any;
+
+  constructor(status: number, body: any) {
+    super(`Failed to update assistant: ${status}`);
+    this.status = status;
+    this.body = body;
+    Object.setPrototypeOf(this, UpdateAssistantError.prototype);
+  }
+}
+
+const baseUrl = process.env.VAPI_API_URL || 'https://api.vapi.ai';
+
+export async function getAssistant(
+  id: string,
+  token = process.env.VAPI_PRIVATE_KEY
+) {
+  if (!token) {
+    throw new Error('VAPI token not provided');
+  }
+
+  const url = new URL(`/assistant/${id}`, baseUrl);
+
+  const res = await retry(() =>
+    fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'User-Agent': 'spoqen-dashboard/1.0',
+      },
+      signal: AbortSignal.timeout(10000),
+    })
+  );
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch assistant: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+export async function updateAssistant(
+  id: string,
+  dto: AssistantDTO,
+  token = process.env.VAPI_PRIVATE_KEY
+) {
+  if (!token) {
+    throw new Error('VAPI token not provided');
+  }
+
+  const url = new URL(`/assistant/${id}`, baseUrl);
+  const body: any = {};
+
+  if (dto.firstMessage !== undefined) {
+    body.firstMessage = dto.firstMessage;
+  }
+  if (dto.voice) {
+    body.voice = dto.voice;
+  }
+  if (dto.systemPrompt !== undefined) {
+    body.model = {
+      provider: 'openai',
+      model: 'gpt-4o',
+      messages: [{ role: 'system', content: dto.systemPrompt }],
+    };
+  }
+
+  const res = await retry(() =>
+    fetch(url.toString(), {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'User-Agent': 'spoqen-dashboard/1.0',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10000),
+    })
+  );
+
+  const json = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    throw new UpdateAssistantError(res.status, json);
+  }
+
+  return json;
+}


### PR DESCRIPTION
## Summary
- add retry helper for API calls
- implement getAssistant and updateAssistant helpers
- cover updateAssistant with basic tests

## Testing
- `npx tsx __tests__/vapi-assistant.test.ts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_6851e6c008c08330bf9b9dc2e1a22891