### PR TITLE
Add dashboard metrics helper for Vapi

### DIFF
--- a/app/api/vapi/dashboard-metrics/route.ts
+++ b/app/api/vapi/dashboard-metrics/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getMetrics } from '@/lib/vapi/getDashboardMetrics';
+import { logger } from '@/lib/logger';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  if (!from || !to) {
+    return NextResponse.json(
+      { error: 'Missing from or to parameters' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const metrics = await getMetrics(from, to);
+    return NextResponse.json({ metrics });
+  } catch (error) {
+    logger.error('VAPI', 'Failed to fetch dashboard metrics', error as Error);
+    return NextResponse.json(
+      { error: 'Failed to fetch dashboard metrics' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/stats-cards.tsx
+++ b/components/stats-cards.tsx
@@ -1,7 +1,35 @@
+'use client';
+
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { BarChart3, PhoneCall, PhoneIncoming, PhoneOff } from 'lucide-react';
+import { useDashboardMetrics } from '@/hooks/use-dashboard-metrics';
 
 export function StatsCards() {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(to.getDate() - 30);
+
+  const { metrics, loading, error } = useDashboardMetrics(
+    from.toISOString(),
+    to.toISOString()
+  );
+
+  const total = metrics?.total ?? 0;
+  const answered = metrics?.answered ?? 0;
+  const missed = metrics?.missed ?? 0;
+  const conversionRate = metrics ? Math.round(metrics.conversionRate * 100) : 0;
+
+  const renderContent = (value: React.ReactNode, extra?: string) => {
+    if (loading) return <div className="text-sm text-muted-foreground">Loading...</div>;
+    if (error) return <div className="text-sm text-red-600">Error</div>;
+    return (
+      <>
+        <div className="text-2xl font-bold">{value}</div>
+        {extra && <p className="text-xs text-muted-foreground">{extra}</p>}
+      </>
+    );
+  };
+
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
       <Card>
@@ -9,10 +37,7 @@ export function StatsCards() {
           <CardTitle className="text-sm font-medium">Total Calls</CardTitle>
           <PhoneCall className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">45</div>
-          <p className="text-xs text-muted-foreground">+12% from last month</p>
-        </CardContent>
+        <CardContent>{renderContent(total, 'last 30 days')}</CardContent>
       </Card>
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -20,8 +45,10 @@ export function StatsCards() {
           <PhoneIncoming className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">38</div>
-          <p className="text-xs text-muted-foreground">84% answer rate</p>
+          {renderContent(
+            answered,
+            total ? `${Math.round((answered / total) * 100)}% answer rate` : ''
+          )}
         </CardContent>
       </Card>
       <Card>
@@ -30,8 +57,10 @@ export function StatsCards() {
           <PhoneOff className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">7</div>
-          <p className="text-xs text-muted-foreground">-23% from last month</p>
+          {renderContent(
+            missed,
+            total ? `${Math.round((missed / total) * 100)}% missed` : ''
+          )}
         </CardContent>
       </Card>
       <Card>
@@ -40,8 +69,10 @@ export function StatsCards() {
           <BarChart3 className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">24%</div>
-          <p className="text-xs text-muted-foreground">+5% from last month</p>
+          {renderContent(
+            `${conversionRate}%`,
+            answered ? `from ${answered} answered` : ''
+          )}
         </CardContent>
       </Card>
     </div>

--- a/hooks/use-dashboard-metrics.tsx
+++ b/hooks/use-dashboard-metrics.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { DashboardMetrics } from '@/lib/vapi/getDashboardMetrics';
+
+export function useDashboardMetrics(fromISO: string, toISO: string) {
+  const [metrics, setMetrics] = useState<DashboardMetrics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const fetchMetrics = async () => {
+      try {
+        const params = new URLSearchParams({ from: fromISO, to: toISO });
+        const res = await fetch(`/api/vapi/dashboard-metrics?${params}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Request failed with ${res.status}`);
+        }
+        const data = await res.json();
+        setMetrics(data.metrics ?? data);
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchMetrics();
+    return () => controller.abort();
+  }, [fromISO, toISO]);
+
+  return { metrics, loading, error };
+}

--- a/lib/constants/vapi.ts
+++ b/lib/constants/vapi.ts
@@ -1,0 +1,6 @@
+export const MISSED_CODES = new Set([
+  'customer-did-not-answer',
+  'customer-busy',
+  'voicemail',
+  'no-routes-available',
+]);

--- a/lib/vapi/getDashboardMetrics.ts
+++ b/lib/vapi/getDashboardMetrics.ts
@@ -1,0 +1,219 @@
+/**
+ * 🏷  PROJECT:  Spoqen — “Speaky” Interactive AI Voicemail
+ * FILE:       src/lib/vapi/getDashboardMetrics.ts
+ *
+ * PURPOSE
+ * --------
+ * Pull raw call records from **Vapi** and aggregate them into the key
+ * KPIs shown on the Speaky web dashboard.  These metrics appear on the
+ * “📈  Call Overview” card at the top of /dashboard/calls.
+ *
+ * METRICS WE NEED
+ * 1. total            – total # of calls in the date range
+ * 2. answered         – calls the AI actually connected and spoke
+ * 3. missed           – rings / busy / voicemail (customer never talked)
+ * 4. conversionRate   – % of *answered* calls where metadata.converted === true
+ * 5. avgDuration      – mean `durationSeconds` across answered calls
+ *
+ * BUSINESS RULES
+ * ---------------
+ *   MISSED_CODES = {
+ *     "customer-did-not-answer",
+ *     "customer-busy",
+ *     "voicemail",
+ *     "no-routes-available"
+ *   }
+ *   answered  = status === "completed" && !MISSED_CODES.has(endedReason)
+ *   missed    = MISSED_CODES.has(endedReason)
+ *   converted = metadata?.converted === true
+ *   conversionRate = answered ? converted / answered : 0
+ *
+ * VAPI REST CONTRACT
+ * ------------------
+ *   BASE    : https://api.vapi.ai
+ *   LIST    : GET /call
+ *     query : from=<ISO>    required (inclusive)
+ *             to=<ISO>      required (inclusive)
+ *             limit=100     optional (default 100)
+ *             cursor=<str>  pagination cursor from previous page
+ *   AUTH    : Authorization: Bearer ${VAPI_TOKEN}
+ *
+ *   Response:
+ *   {
+ *     "data": Call[],
+ *     "nextCursor": string | null
+ *   }
+ *
+ *   Call (subset):
+ *   {
+ *     id: string;
+ *     status: "completed" | "failed" | "in_progress" | ...;
+ *     endedReason: string;               // see MISSED_CODES
+ *     durationSeconds: number;
+ *     metadata?: { converted?: boolean };
+ *   }
+ *
+ * IMPLEMENTATION
+ * --------------
+ * export async function getMetrics(
+ *   fromISO: string,
+ *   toISO:   string,
+ *   token   = process.env.VAPI_TOKEN
+ * ): Promise<{
+ *   total: number;
+ *   answered: number;
+ *   missed: number;
+ *   conversionRate: number; // 0–1
+ *   avgDuration: number;    // seconds
+ * }>
+ *
+ * – Fetch pages until nextCursor === null.
+ * – Retry up to 3x on 5xx or network errors (exponential back-off).
+ * – No console.log; return typed object only.
+ * – Throw descriptive Error on non-200 response.
+ *
+ * ENV
+ * ---
+ *   we have the following ENV structure
+NEXT_PUBLIC_SUPABASE_URL
+VAPI_PRIVATE_KEY
+VAPI_PUBLIC_KEY
+VAPI_ASSISTANT_ID
+VAPI_PHONE_NUMBER_ID
+NEXT_PUBLIC_SUPABASE_ANON_KEY
+ *
+ * NOTE
+ * ----
+ * If Vapi adds new `endedReason` codes, MISSED_CODES should be updated
+ * in ./constants/vapi.ts (single source of truth).
+ */
+
+import { MISSED_CODES } from '@/lib/constants/vapi';
+import { logger } from '@/lib/logger';
+
+export interface DashboardMetrics {
+  total: number;
+  answered: number;
+  missed: number;
+  conversionRate: number;
+  avgDuration: number;
+}
+
+interface VapiCall {
+  id: string;
+  status: string;
+  endedReason: string;
+  durationSeconds: number;
+  metadata?: { converted?: boolean };
+}
+
+interface VapiResponse {
+  data: VapiCall[];
+  nextCursor: string | null;
+}
+
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  attempts = 3,
+  backoff = 500
+): Promise<Response> {
+  try {
+    const res = await fetch(url, options);
+    if (!res.ok && res.status >= 500 && attempts > 1) {
+      await new Promise(r => setTimeout(r, backoff));
+      return fetchWithRetry(url, options, attempts - 1, backoff * 2);
+    }
+    return res;
+  } catch (err) {
+    if (attempts > 1) {
+      await new Promise(r => setTimeout(r, backoff));
+      return fetchWithRetry(url, options, attempts - 1, backoff * 2);
+    }
+    throw err;
+  }
+}
+
+export async function getMetrics(
+  fromISO: string,
+  toISO: string,
+  token = process.env.VAPI_PRIVATE_KEY
+): Promise<DashboardMetrics> {
+  if (!token) {
+    throw new Error('VAPI token not configured');
+  }
+
+  const baseUrl = process.env.VAPI_API_URL || 'https://api.vapi.ai';
+  let cursor: string | null = null;
+
+  let total = 0;
+  let answered = 0;
+  let missed = 0;
+  let conversions = 0;
+  let durationSum = 0;
+
+  do {
+    const url = new URL('/v1/calls', baseUrl);
+    url.searchParams.set('from', fromISO);
+    url.searchParams.set('to', toISO);
+    url.searchParams.set('limit', '100');
+    if (cursor) {
+      url.searchParams.set('cursor', cursor);
+    }
+
+    const res = await fetchWithRetry(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'User-Agent': 'spoqen-dashboard/1.0',
+      },
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `Vapi API request failed with ${res.status} ${res.statusText}`
+      );
+    }
+
+    const json = (await res.json()) as VapiResponse;
+
+    for (const call of json.data) {
+      total++;
+      const callMissed = MISSED_CODES.has(call.endedReason);
+      const callAnswered = call.status === 'completed' && !callMissed;
+
+      if (callAnswered) {
+        answered++;
+        durationSum += call.durationSeconds ?? 0;
+        if (call.metadata?.converted === true) {
+          conversions++;
+        }
+      } else if (callMissed) {
+        missed++;
+      }
+    }
+
+    cursor = json.nextCursor;
+  } while (cursor);
+
+  const avgDuration = answered ? durationSum / answered : 0;
+  const conversionRate = answered ? conversions / answered : 0;
+
+  logger.info('Metrics', 'Dashboard metrics calculated', {
+    fromISO,
+    toISO,
+    total,
+    answered,
+    missed,
+    conversions,
+  });
+
+  return {
+    total,
+    answered,
+    missed,
+    conversionRate,
+    avgDuration,
+  };
+}


### PR DESCRIPTION
## Summary
- create `MISSED_CODES` constant
- add `getMetrics` in `lib/vapi/getDashboardMetrics.ts`
- fetch paginated call records from Vapi and compute dashboard KPIs
- replace placeholder stats with live metrics via `/api/vapi/dashboard-metrics`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_b_6851e3e2ca108330bc464db203dadff9