### PR TITLE
Add sidebar layout for dashboard

### DIFF
--- a/app/admin/site-url/page.tsx
+++ b/app/admin/site-url/page.tsx
@@ -1,11 +1,10 @@
 import { UpdateSiteUrlHelper } from '@/components/update-site-url-helper';
-import { DashboardHeader } from '@/components/dashboard-header';
+import { DashboardLayout } from '@/components/dashboard-layout';
 import { DashboardShell } from '@/components/dashboard-shell';
 
 export default function SiteUrlPage() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <DashboardHeader />
+    <DashboardLayout>
       <DashboardShell>
         <div className="flex items-center justify-between">
           <h2 className="text-3xl font-bold tracking-tight">
@@ -16,6 +15,6 @@ export default function SiteUrlPage() {
           <UpdateSiteUrlHelper />
         </div>
       </DashboardShell>
-    </div>
+    </DashboardLayout>
   );
 }

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -30,7 +30,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { DashboardHeader } from '@/components/dashboard-header';
+import { DashboardLayout } from '@/components/dashboard-layout';
 import { DashboardShell } from '@/components/dashboard-shell';
 import {
   CreditCard,
@@ -284,8 +284,7 @@ startxref
   };
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <DashboardHeader />
+    <DashboardLayout>
       <DashboardShell>
         <div className="flex items-center justify-between">
           <h2 className="text-3xl font-bold tracking-tight">
@@ -691,6 +690,6 @@ startxref
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
+    </DashboardLayout>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -69,7 +69,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { DashboardHeader } from '@/components/dashboard-header';
+import { DashboardLayout } from '@/components/dashboard-layout';
 import { useActionPoints } from '@/hooks/use-action-points';
 import { useDashboardAnalytics } from '@/hooks/use-dashboard-analytics';
 import {
@@ -458,8 +458,7 @@ export default function DashboardPage() {
   if (error) {
     return (
       <ProtectedRoute>
-        <div className="min-h-screen bg-gradient-to-br from-background via-purple-950/10 to-blue-950/10">
-          <DashboardHeader />
+        <DashboardLayout>
           <div className="p-6">
             <Card>
               <CardContent className="pt-6">
@@ -473,16 +472,14 @@ export default function DashboardPage() {
               </CardContent>
             </Card>
           </div>
-        </div>
+        </DashboardLayout>
       </ProtectedRoute>
     );
   }
 
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-gradient-to-br from-background via-purple-950/10 to-blue-950/10">
-        <DashboardHeader />
-
+      <DashboardLayout>
         <div className="space-y-6 p-6">
           {/* Header */}
           <div className="flex items-center justify-between">
@@ -1241,7 +1238,7 @@ export default function DashboardPage() {
             </TabsContent>
           </Tabs>
         </div>
-      </div>
+      </DashboardLayout>
     </ProtectedRoute>
   );
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -13,7 +13,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { DashboardHeader } from '@/components/dashboard-header';
+import { DashboardLayout } from '@/components/dashboard-layout';
 import { DashboardShell } from '@/components/dashboard-shell';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Camera, Save, Loader2 } from 'lucide-react';
@@ -367,8 +367,7 @@ function ProfilePageContent() {
   // Show loading state
   if (loading && !dataLoaded) {
     return (
-      <div className="flex min-h-screen flex-col">
-        <DashboardHeader />
+      <DashboardLayout>
         <DashboardShell>
           <div className="flex min-h-[400px] items-center justify-center">
             <div className="flex flex-col items-center space-y-4">
@@ -379,13 +378,12 @@ function ProfilePageContent() {
             </div>
           </div>
         </DashboardShell>
-      </div>
+      </DashboardLayout>
     );
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <DashboardHeader />
+    <DashboardLayout>
       <DashboardShell>
         <div className="flex items-center justify-between">
           <h2 className="text-3xl font-bold tracking-tight">Profile</h2>
@@ -675,7 +673,7 @@ function ProfilePageContent() {
           </form>
         </div>
       </DashboardShell>
-    </div>
+    </DashboardLayout>
   );
 }
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -29,7 +29,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { DashboardHeader } from '@/components/dashboard-header';
+import { DashboardLayout } from '@/components/dashboard-layout';
 import { DashboardShell } from '@/components/dashboard-shell';
 import AddressAutocomplete from '@/components/AddressAutocomplete';
 import { Camera, Bell, Shield, User } from 'lucide-react';
@@ -1125,8 +1125,7 @@ function SettingsContent() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <DashboardHeader />
+    <DashboardLayout>
       <DashboardShell>
         <div className="flex items-center justify-between">
           <h2 className="text-3xl font-bold tracking-tight">Settings</h2>
@@ -1782,7 +1781,7 @@ function SettingsContent() {
           </TabsContent>
         </Tabs>
       </DashboardShell>
-    </div>
+    </DashboardLayout>
   );
 }
 

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { DashboardSidebar } from '@/components/dashboard-sidebar';
+import { DashboardHeader } from '@/components/dashboard-header';
+
+interface DashboardLayoutProps {
+  children: ReactNode;
+}
+
+export function DashboardLayout({ children }: DashboardLayoutProps) {
+  return (
+    <div className="flex min-h-screen">
+      <DashboardSidebar />
+      <div className="flex flex-1 flex-col bg-gradient-to-br from-background via-purple-950/10 to-blue-950/10">
+        <DashboardHeader />
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, Users, Receipt, Settings, HelpCircle, LogOut } from 'lucide-react';
+import { useAuth } from '@/hooks/use-auth';
+import Logo from '@/components/ui/logo';
+
+function isActive(path: string, pathname: string) {
+  return pathname === path;
+}
+
+export function DashboardSidebar() {
+  const pathname = usePathname();
+  const { signOut } = useAuth();
+
+  const itemClass = (path: string) =>
+    `flex items-center space-x-3 px-4 py-3 rounded-lg ${isActive(path, pathname) ? 'bg-sidebar-accent text-sidebar-accent-foreground shadow' : 'text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'}`;
+
+  return (
+    <aside className="bg-sidebar text-sidebar-foreground w-64 p-6 space-y-6 flex flex-col justify-between">
+      <div>
+        <div className="flex items-center space-x-2 mb-10">
+          <Link href="/">
+            <Logo width={120} height={40} />
+          </Link>
+        </div>
+        <nav className="space-y-2">
+          <Link href="/dashboard" className={itemClass('/dashboard')}>
+            <LayoutDashboard className="h-5 w-5" />
+            <span>Dashboard</span>
+          </Link>
+          <Link href="/profile" className={itemClass('/profile')}>
+            <Users className="h-5 w-5" />
+            <span>Profile</span>
+          </Link>
+          <Link href="/billing" className={itemClass('/billing')}>
+            <Receipt className="h-5 w-5" />
+            <span>Billing</span>
+          </Link>
+        </nav>
+      </div>
+      <div className="space-y-2">
+        <Link href="/settings" className={itemClass('/settings')}>
+          <Settings className="h-5 w-5" />
+          <span>Settings</span>
+        </Link>
+        <Link href="/contact" className={itemClass('/contact')}>
+          <HelpCircle className="h-5 w-5" />
+          <span>Help Center</span>
+        </Link>
+        <button
+          onClick={() => signOut()}
+          className="flex items-center space-x-3 px-4 py-3 rounded-lg text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground w-full"
+        >
+          <LogOut className="h-5 w-5" />
+          <span>Logout</span>
+        </button>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `DashboardSidebar` with navigation links
- create `DashboardLayout` that uses the sidebar and header
- integrate the new layout into dashboard-related pages

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: Type errors in other parts of repo)*

------
https://chatgpt.com/codex/tasks/task_b_68649906fbf483309e1cad0c600e23aa