### PR TITLE
Fix business name regex

### DIFF
--- a/__tests__/validation-patterns.test.ts
+++ b/__tests__/validation-patterns.test.ts
@@ -6,7 +6,7 @@
 const VALIDATION_PATTERNS = {
   NAME_PATTERN: /^[a-zA-Z](?:[a-zA-Z\s\-'.])*[a-zA-Z]$|^[a-zA-Z]$/,
   BUSINESS_NAME_PATTERN:
-    /^[a-zA-Z0-9](?:[a-zA-Z0-9\s\-'.,&()]*[a-zA-Z0-9.)])?$/,
+    /^(?!.* {2})(?!.*--)(?!.*\.{2})(?!.*,{2})(?!.*'')(?!.*&&)(?!.*\(\()(?!.*\)\))[a-zA-Z0-9](?:[a-zA-Z0-9\s\-'.,&()]*[a-zA-Z0-9.)])?$/,
 };
 
 // Simple test runner

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -446,7 +446,7 @@ export default function DashboardPage() {
   const VALIDATION_PATTERNS = {
     NAME_PATTERN: /^[\p{L}](?:[\p{L}\s\-'.])*[\p{L}]$|^[\p{L}]$/u,
     BUSINESS_NAME_PATTERN:
-      /^[a-zA-Z0-9](?:[a-zA-Z0-9\s\-'.,&()]*[a-zA-Z0-9.)])?$/,
+      /^(?!.* {2})(?!.*--)(?!.*\.{2})(?!.*,{2})(?!.*'')(?!.*&&)(?!.*\(\()(?!.*\)\))[a-zA-Z0-9](?:[a-zA-Z0-9\s\-'.,&()]*[a-zA-Z0-9.)])?$/,
   };
 
   const validateContent = (field: string, value: string): string | null => {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -380,7 +380,7 @@ function SettingsContent() {
 
     // Business names: alphanumeric, single spaces, limited punctuation
     BUSINESS_NAME_PATTERN:
-      /^(?:[A-Za-z0-9](?:[A-Za-z0-9\s\-'.&,()]*[A-Za-z0-9])?)$/,
+      /^(?!.* {2})(?!.*--)(?!.*\.{2})(?!.*,{2})(?!.*'')(?!.*&&)(?!.*\(\()(?!.*\)\))[A-Za-z0-9](?:[A-Za-z0-9\s\-'.&,()]*[A-Za-z0-9.)])?$/,
 
     // Email pattern supporting RFC-5322 compliant characters including '+' in local part
     // Allows letters, numbers, dots, underscores, hyphens, and plus signs in local part


### PR DESCRIPTION
## Summary
- tighten `BUSINESS_NAME_PATTERN` regex to reject consecutive punctuation
- keep tests in sync with updated validation logic

## Testing
- `npx tsc __tests__/validation-patterns.test.ts --target ES2019 --module commonjs --outDir /tmp/test-dist && node /tmp/test-dist/validation-patterns.test.js`

------
https://chatgpt.com/codex/tasks/task_b_686d1bc4cb548330a2f0585460e10326