### PR TITLE
fix: enhance instance management in VapiWidgetInner for better resour…

### DIFF
--- a/components/vapi-widget.tsx
+++ b/components/vapi-widget.tsx
@@ -72,26 +72,30 @@ function VapiWidgetInner({
 
     // Aggressive cleanup – stop calls when tab hidden or on unmount
     const handleVisibilityChange = () => {
-      if (document.hidden) {
+      if (document.hidden && instance) {
         instance.stop();
       }
     };
     const handleBeforeUnload = () => {
-      instance.stop();
+      if (instance) {
+        instance.stop();
+      }
     };
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('beforeunload', handleBeforeUnload);
 
     return () => {
-      instance.off('call-start', handleCallStart);
-      instance.off('call-end', handleCallEnd);
-      instance.off('speech-start', handleSpeechStart);
-      instance.off('speech-end', handleSpeechEnd);
-      instance.off('error', handleError);
+      if (instance) {
+        instance.off('call-start', handleCallStart);
+        instance.off('call-end', handleCallEnd);
+        instance.off('speech-start', handleSpeechStart);
+        instance.off('speech-end', handleSpeechEnd);
+        instance.off('error', handleError);
+        instance.stop();
+      }
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('beforeunload', handleBeforeUnload);
-      instance.stop();
     };
     // Note: we intentionally exclude `config` from deps to avoid recreating the
     // Vapi instance on every render when callers pass an inline object.
@@ -102,7 +106,9 @@ function VapiWidgetInner({
   }, [assistantId]);
 
   const endCall = useCallback(() => {
-    vapiRef.current?.stop();
+    if (vapiRef.current) {
+      vapiRef.current.stop();
+    }
   }, []);
 
   // SDK not yet ready – render nothing


### PR DESCRIPTION
This pull request improves the stability of the `VapiWidgetInner` component in `components/vapi-widget.tsx` by adding null checks for the `instance` and `vapiRef.current` objects before calling their methods. These changes ensure that the application avoids potential runtime errors caused by undefined or null references.

### Stability improvements:

* Added a null check for `instance` in the `handleVisibilityChange` and `handleBeforeUnload` functions to ensure `instance.stop()` is only called when `instance` is defined.
* Updated the cleanup logic in the `useEffect` return function to add a null check for `instance` before calling its `off` methods and `stop` method. This prevents errors during component unmounting.
* Added a null check for `vapiRef.current` in the `endCall` function to ensure `vapiRef.current.stop()` is only called when `vapiRef.current` is defined.…ce cleanup

- Added checks to ensure the instance is defined before calling stop and off methods, preventing potential errors during visibility change and component unmounting.
- Improved the endCall function to safely stop the Vapi instance if it exists, enhancing overall stability and resource management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability by adding safeguards to prevent errors when certain objects are unavailable during call handling and cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->