### PR TITLE
feat: add retry functionality to call history table

### DIFF
--- a/app/recent-calls/RecentCallsClient.tsx
+++ b/app/recent-calls/RecentCallsClient.tsx
@@ -352,6 +352,7 @@ export default function RecentCallsClient() {
                 calls={filteredAndPaginatedCalls.calls}
                 isLoading={isLoading}
                 error={error ? (error as Error).message : null}
+                onRetry={refetch}
                 searchTerm={searchTerm}
                 onSearchChange={handleSearchChange}
                 sentimentFilter={sentimentFilter}

--- a/components/dashboard/call-history-table.tsx
+++ b/components/dashboard/call-history-table.tsx
@@ -42,6 +42,7 @@ interface CallHistoryTableProps {
   calls: VapiCall[];
   isLoading: boolean;
   error: string | null;
+  onRetry: () => void;
   searchTerm: string;
   onSearchChange: (value: string) => void;
   sentimentFilter: string;
@@ -64,6 +65,7 @@ export const CallHistoryTable = memo(
     calls,
     isLoading,
     error,
+    onRetry,
     searchTerm,
     onSearchChange,
     sentimentFilter,
@@ -117,7 +119,13 @@ export const CallHistoryTable = memo(
           </CardHeader>
           <CardContent>
             <div className="py-8 text-center">
-              <p className="text-destructive">Error loading calls: {error}</p>
+              <p className="mb-4 text-destructive">
+                We couldn't load your calls. This might be due to a network
+                issue.
+              </p>
+              <Button variant="outline" onClick={onRetry}>
+                Try again
+              </Button>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
This pull request introduces a retry mechanism for loading call data in the `CallHistoryTable` component. It enhances the user experience by providing a clearer error message and a retry button in case of network issues.

### Enhancements to Error Handling and Retry Mechanism:

* [`app/recent-calls/RecentCallsClient.tsx`](diffhunk://#diff-be38862f98443ca42eb6e9d733d54c31e3d48b3e62bde54dd0b6e767507d47d8R355): Added the `onRetry` prop to the `RecentCallsClient` component, which is linked to the `refetch` function for retrying data fetching.
* `components/dashboard/call-history-table.tsx`:
  * Updated the `CallHistoryTableProps` interface to include the new `onRetry` callback prop.
  * Passed the `onRetry` prop through the `CallHistoryTable` component.
  * Enhanced the error message display to include a retry button with a more user-friendly message. The button triggers the `onRetry` callback when clicked.- Introduced an onRetry prop to the CallHistoryTable component to handle retry logic for loading calls.
- Updated the error message display to provide a clearer user experience, including a button for retrying the call loading process.

These changes enhance the user interface by allowing users to retry loading calls after an error occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Try again" button to the call history table, allowing users to retry loading recent calls after an error.
  * Improved error messages for better clarity in case of network issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->